### PR TITLE
Add a case-sensitive filename experiment

### DIFF
--- a/DOCS/case-sensitivity-lab/UPPER.txt
+++ b/DOCS/case-sensitivity-lab/UPPER.txt
@@ -1,0 +1,4 @@
+This file uses an uppercase basename.
+
+On a case-sensitive filesystem it is a different path from `upper.txt` in the
+same directory. That distinction is the experiment.

--- a/DOCS/case-sensitivity-lab/upper.txt
+++ b/DOCS/case-sensitivity-lab/upper.txt
@@ -1,0 +1,4 @@
+This file uses a lowercase basename.
+
+On a case-sensitive filesystem it is a different path from `UPPER.txt` in the
+same directory. Some case-insensitive checkouts will report a collision.


### PR DESCRIPTION
## What this breaks

Adds two files whose basenames differ only by case:

- `DOCS/case-sensitivity-lab/UPPER.txt`
- `DOCS/case-sensitivity-lab/upper.txt`

## Why it is harmless

This is a repository-local cross-platform filename experiment. Case-sensitive
checkouts keep both files, while case-insensitive filesystems can surface the
collision during checkout. The files contain only explanatory text; no tooling,
external service, or user data is involved.
