### PR TITLE
Add a Unicode path rendering experiment

### DIFF
--- a/DOCS/🧪.md
+++ b/DOCS/🧪.md
@@ -1,0 +1,9 @@
+# The Unicode path experiment
+
+The filename of this document is a test fixture, not a typo. It contains a
+single emoji code point so that GitHub's tree, diff view, and local tools have
+to render a non-ASCII path consistently.
+
+If a checkout displays a replacement glyph, escapes the name, or cannot open
+the file, that is the visible effect this tiny experiment is meant to expose.
+Nothing in the file is executable, and no external service is referenced.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/🧪.md`, a harmless Markdown file whose path contains an emoji.

## Why it is harmless

The file is plain explanatory text and has no executable content or external
links. It exercises GitHub's tree/diff rendering and local checkout handling of
non-ASCII paths, making any display or tooling issue visible without affecting
runtime behavior.
