### PR TITLE
Add fictional future release notes

### DIFF
--- a/DOCS/RELEASE_NOTES_2099.md
+++ b/DOCS/RELEASE_NOTES_2099.md
@@ -1,0 +1,21 @@
+# Break This Repository 2099.13
+
+> Fictional release notes. The calendar is part of the bug.
+
+This release is an intentionally impossible announcement for a repository that
+already treats its own documentation as a playground. It is not a promise of
+features, a security advisory, or a statement about any real project.
+
+## Highlights
+
+- The merge queue now accepts pull requests from yesterday, provided they were
+  opened tomorrow.
+- A new `--please` flag politely asks Git to rewrite history and then declines
+  to do so.
+- Release artifacts are shipped as a thought, with no download required.
+
+## Known contradictions
+
+The version number is fictional, the features above are not implemented, and
+the phrase “new” has no stable meaning in a repository that automatically
+merges changes. Treat this page as a harmless text-only rendering experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/RELEASE_NOTES_2099.md`, a clearly labeled fictional release announcement with intentionally impossible features and a contradictory version.

## Why it is harmless

This is a text-only documentation experiment, explicitly marked as fiction. It changes no code, workflow, protected content, or external systems, and it makes no real release or security claims.
