### PR TITLE
Add an unbound Markdown reference experiment

### DIFF
--- a/DOCS/UNBOUND_REFERENCE.md
+++ b/DOCS/UNBOUND_REFERENCE.md
@@ -1,0 +1,12 @@
+# Unbound reference link
+
+This sentence contains [a link-shaped reference][the-door-that-isn't-there].
+
+There is deliberately no reference definition for
+`the-door-that-isn't-there`. CommonMark-compatible renderers should leave the
+reference unresolved, while other Markdown implementations may display it in a
+different way. That disagreement is the experiment.
+
+The missing target is local to this document and does not cause a request to
+any real website. If you turn this into a real link, please keep it inside the
+repository and update this explanation.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/UNBOUND_REFERENCE.md` with a Markdown reference link that has no definition.

## Why it is harmless

The missing target is intentional and local to the document. It exercises differences between Markdown renderers without contacting a real website, changing code, or touching protected paths.
