### PR TITLE
Add a no-extension rendering experiment

### DIFF
--- a/DOCS/NO_EXTENSION
+++ b/DOCS/NO_EXTENSION
@@ -1,0 +1,7 @@
+No extension, no problem.
+
+This file intentionally has no suffix. GitHub and local tools must infer that
+it is plain text without the usual `.md`, `.txt`, or source-language hint.
+
+Nothing here is a configuration file or an instruction to execute anything;
+the ambiguity is the whole repository-local experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/NO_EXTENSION`, a plain-text document with no filename extension.

## Why it is harmless

The file contains only explanatory text. It exercises how GitHub and local tools infer content for an extensionless path, without changing runtime code, workflows, protected content, or external systems.
