### PR TITLE
Add a Markdown whitespace fixture

### DIFF
--- a/DOCS/WHITESPACE_FIXTURE.md
+++ b/DOCS/WHITESPACE_FIXTURE.md
@@ -1,0 +1,13 @@
+# Whitespace fixture
+
+These two lines are intentionally similar but not byte-identical. The first
+uses four spaces after the label; the second uses one tab.
+
+```text
+spaces:    four columns
+tabs:	one tab character
+```
+
+The code fence keeps the characters visible instead of asking a parser to
+interpret them as indentation. Reviewers can inspect the raw file or a hex
+viewer to see the difference. There is no executable snippet here.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/WHITESPACE_FIXTURE.md`, a fenced example containing visually similar lines that use spaces and a tab.

## Why it is harmless

The characters are inside a text-only code fence and are never executed or parsed as repository configuration. The fixture simply makes whitespace differences visible to Markdown, diff, and review tooling.
