### PR TITLE
Add a hidden path rendering experiment

### DIFF
--- a/DOCS/.hidden-experiment
+++ b/DOCS/.hidden-experiment
@@ -1,0 +1,5 @@
+You found the hidden document.
+
+The leading dot is intentional. It tests whether repository browsers and
+development tools show hidden paths consistently. This is plain text only; it
+does not configure ignore rules or hide any real data.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/.hidden-experiment`, a plain-text file with a leading-dot basename.

## Why it is harmless

The file contains no configuration, ignore rules, executable content, or secrets. It only exercises whether repository browsers and local tools display hidden paths consistently.
