### PR TITLE
Add a relative link typo experiment

### DIFF
--- a/DOCS/RELATIVE_LINK_MIRAGE.md
+++ b/DOCS/RELATIVE_LINK_MIRAGE.md
@@ -1,0 +1,10 @@
+# Relative-link mirage
+
+The repository already contains `DOCS/README_of_nothing.md`. This link is
+deliberately one punctuation mark away from that path:
+
+[Open the almost-right document](./README-of-nothing.md)
+
+The hyphen is not an underscore, so the target should fail on every checkout.
+It is a local, read-only link-resolution experiment; no network request is
+needed and no existing file is changed.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/RELATIVE_LINK_MIRAGE.md` with a repository-local link whose target differs from an existing path by one punctuation character.

## Why it is harmless

The link is explicitly documented as intentional, points only within the repository, and cannot contact an external service. It changes no existing files, code, workflows, or protected content.
