### PR TITLE
Add a nested blockquote rendering experiment

### DIFF
--- a/DOCS/BLOCKQUOTE_STAIRCASE.md
+++ b/DOCS/BLOCKQUOTE_STAIRCASE.md
@@ -1,0 +1,15 @@
+# Blockquote staircase
+
+The indentation below increases one level at a time. It is deliberately more
+of a rendering stress test than a useful conversation.
+
+> level 1
+>> level 2
+>>> level 3
+>>>> level 4
+>>>>> level 5
+>>>>>> level 6
+
+Every line is ordinary Markdown text. If a renderer flattens the staircase or
+wraps it unexpectedly, the difference is visible here without any executable
+content or external dependency.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/BLOCKQUOTE_STAIRCASE.md` with six progressively nested Markdown blockquotes.

## Why it is harmless

The page is text-only and isolated under `DOCS/`. It exercises Markdown indentation, wrapping, and renderer behavior without changing code, workflows, protected content, or external systems.
