### PR TITLE
Add a ragged Markdown table experiment

### DIFF
--- a/DOCS/RAGGED_TABLE.md
+++ b/DOCS/RAGGED_TABLE.md
@@ -1,0 +1,14 @@
+# Ragged table
+
+This table intentionally gives one row more pipe-separated cells than the
+header advertises. Markdown renderers disagree on whether to discard the
+extra cells, display them, or treat the row as plain text.
+
+| file | mood |
+| --- | --- |
+| `README.md` | protected above the marker |
+| `DOCS/` | fair game | extra cell |
+| `assets/` | pictures, words, and experiments |
+
+The mismatch is confined to this example and contains no data that a program
+should consume. It exists to make parser behavior visible in a diff.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/RAGGED_TABLE.md` with one Markdown table row containing an extra cell beyond the header.

## Why it is harmless

The mismatch is isolated to a text-only example and is explicitly explained. It exercises renderer/parser tolerance without changing code, workflows, protected content, or external systems.
