### PR TITLE
Add an incomplete Mermaid rendering fixture

### DIFF
--- a/DOCS/MERMAID_GLITCH.md
+++ b/DOCS/MERMAID_GLITCH.md
@@ -1,0 +1,15 @@
+# Mermaid glitch fixture
+
+The fenced diagram below is intentionally incomplete. A Mermaid-capable
+renderer may show an error, a blank panel, or the source text depending on its
+version.
+
+```mermaid
+flowchart LR
+    visitor[Visitor] --> pull_request[Pull request]
+    pull_request -->
+```
+
+The unfinished edge is the entire experiment. It is isolated in a document,
+contains no script that can run, and does not change the repository's own
+workflow definitions.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/MERMAID_GLITCH.md` with an intentionally unfinished Mermaid edge inside a fenced diagram.

## Why it is harmless

The fixture is isolated documentation with no executable script or workflow change. It exercises renderer error handling while explicitly explaining that the diagram is incomplete.
