### PR TITLE
Add an HTML comment rendering trap

### DIFF
--- a/DOCS/HTML_COMMENT_TRAP.md
+++ b/DOCS/HTML_COMMENT_TRAP.md
@@ -1,0 +1,15 @@
+# HTML comment trap
+
+The block below is intentionally hidden by an HTML comment. GitHub-flavored
+Markdown usually suppresses it, while a plain-text viewer will show every
+character.
+
+<!-- BEGIN THE INVISIBLE PARADE
+
+This sentence is part of the fixture and should not be visible in a rendered
+preview. It is not a secret, credential, or instruction.
+
+END THE INVISIBLE PARADE -->
+
+The closing delimiter is present on purpose so that the rest of this document
+remains visible. The experiment is limited to rendering behavior.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/HTML_COMMENT_TRAP.md` with a short, explicitly non-secret block hidden inside an HTML comment.

## Why it is harmless

The fixture is isolated documentation and the comment is closed before the rest of the page. It contains no credentials, instructions, executable content, or external references; it only exposes rendered-versus-raw visibility differences.
