### PR TITLE
Add Unicode normalization filename fixtures

### DIFF
--- a/DOCS/café.md
+++ b/DOCS/café.md
@@ -1,0 +1,8 @@
+# NFD filename
+
+This document uses the decomposed Unicode filename `café.md` (NFD).
+It looks the same as the sibling NFC fixture, but the underlying code points
+are different.
+
+The content is plain text. The filename is the experiment: tools that
+normalize paths may treat these two documents as one.

--- a/DOCS/café.md
+++ b/DOCS/café.md
@@ -1,0 +1,8 @@
+# NFC filename
+
+This document uses the precomposed Unicode filename `café.md` (NFC).
+It looks the same as the sibling NFD fixture, but the underlying code points
+are different.
+
+The content is plain text. The filename is the experiment: tools that
+normalize paths may treat these two documents as one.


### PR DESCRIPTION
## What this breaks

Adds two text-only documents that look like `café.md` but use different Unicode normalization forms: NFC (precomposed) and NFD (decomposed).

## Why it is harmless

The files contain explanatory text only. The deliberate path difference exercises checkout and tooling behavior on Unicode-normalizing filesystems, without changing code, workflows, protected content, or external systems.
