### PR TITLE
Add a Unicode line separator fixture

### DIFF
--- a/DOCS/UNICODE_LINE_SEPARATOR.md
+++ b/DOCS/UNICODE_LINE_SEPARATOR.md
@@ -1,0 +1,11 @@
+# Unicode line-separator fixture
+
+The next line contains a U+2028 character between the two words. It may look
+like a line break in some editors, but it is a character inside one Markdown
+paragraph.
+
+left right
+
+This is intentionally plain text. The fixture lets viewers compare how GitHub,
+terminals, and editors split or display Unicode line separators without giving
+any program something to execute.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/UNICODE_LINE_SEPARATOR.md` with a U+2028 character between two words in a standalone paragraph.

## Why it is harmless

The fixture is plain explanatory text and contains no executable or configuration content. It only exposes how editors, terminals, GitHub, and Markdown parsers treat a Unicode line-separator character.
