### PR TITLE
Add a broken image rendering fixture

### DIFF
--- a/DOCS/BROKEN_IMAGE.md
+++ b/DOCS/BROKEN_IMAGE.md
@@ -1,0 +1,10 @@
+# Broken image fixture
+
+The image below deliberately points at a path that does not exist:
+
+![A placeholder cat that was never uploaded](./assets/cat-that-was-never-uploaded.png)
+
+Browsers should display the alt text (and often a broken-image indicator) while
+offline documentation tools may report a missing asset. The target is local to
+this repository, so the fixture never contacts a real service or sends data
+anywhere.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/BROKEN_IMAGE.md` with a Markdown image pointing at an intentionally missing local asset.

## Why it is harmless

The page explains the expected broken-image/alt-text behavior. The target is repository-local and nonexistent, so no external request, executable content, workflow change, or protected-path edit is involved.
