### PR TITLE
Add an invalid JSON syntax fixture

### DIFF
--- a/DOCS/INVALID_JSON_FIXTURE.md
+++ b/DOCS/INVALID_JSON_FIXTURE.md
@@ -1,0 +1,15 @@
+# Invalid JSON fixture
+
+This fenced block is labeled `json` but intentionally contains a trailing
+comma. A strict parser should reject it; a syntax highlighter may still color
+it as if it were valid JSON.
+
+```json
+{
+  "repository": "break-this-repo",
+  "mood": "chaotic",
+}
+```
+
+The snippet is documentation only. It is not read by a build, workflow, or
+application, and it contains no secrets or instructions to execute it.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/INVALID_JSON_FIXTURE.md` with a fenced `json` block that has an intentional trailing comma.

## Why it is harmless

The snippet is documentation only and is not loaded by any build, workflow, or application. It contains no secrets or executable instructions and exists solely to compare syntax-highlighting and strict-parser behavior.
