### PR TITLE
Add an invalid YAML syntax fixture

### DIFF
--- a/DOCS/INVALID_YAML_FIXTURE.md
+++ b/DOCS/INVALID_YAML_FIXTURE.md
@@ -1,0 +1,15 @@
+# Invalid YAML fixture
+
+This fenced block is labeled `yaml` but its list indentation is intentionally
+inconsistent. Strict YAML readers should reject it; tolerant tooling may report
+a surprising tree.
+
+```yaml
+repository: break-this-repo
+experiments:
+  - broken-link
+   - extra-indent
+```
+
+It is a documentation-only sample. Nothing in the repository loads this block
+as configuration, and it contains no credentials or executable instructions.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/INVALID_YAML_FIXTURE.md` with a fenced YAML block whose list indentation is intentionally inconsistent.

## Why it is harmless

The sample is documentation-only and is not loaded as configuration by any build or workflow. It contains no secrets or executable instructions and simply exercises parser/highlighter failure behavior.
