### PR TITLE
Add a deep directory path fixture

### DIFF
--- a/DOCS/deep-path/level-1/level-2/level-3/README.md
+++ b/DOCS/deep-path/level-1/level-2/level-3/README.md
@@ -1,0 +1,8 @@
+# Deep path fixture
+
+You had to descend four directory levels to read this page. That is
+intentional: the path itself is the experiment.
+
+Repository browsers may collapse the intermediate folders, while command-line
+tools and relative-link checkers must preserve every segment. The document is
+plain text and has no effect outside this directory.


### PR DESCRIPTION
## What this breaks

Adds a Markdown page four directory levels below `DOCS/` to exercise deep-path navigation and relative-link handling.

## Why it is harmless

The page is plain text, isolated under `DOCS/deep-path/`, and contains no configuration, executable content, or external references. Only repository tree/browsing behavior is affected.
