### PR TITLE
Add a long-line wrapping fixture

### DIFF
--- a/DOCS/LONG_LINE.md
+++ b/DOCS/LONG_LINE.md
@@ -1,0 +1,9 @@
+# Long-line fixture
+
+The next paragraph is intentionally one physical line. Soft-wrapping is left
+to the viewer rather than encoded as newline characters.
+
+meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow
+
+This document contains no generated data or executable content. The long line
+only makes wrapping and horizontal-scrolling behavior observable.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/LONG_LINE.md` with one intentionally long physical line of harmless text.

## Why it is harmless

The line is documentation-only and contains no generated data, code, or external references. It makes soft-wrapping and horizontal-scrolling behavior visible in GitHub, terminals, and diff tools.
