### PR TITLE
Add a Markdown footnote fixture

### DIFF
--- a/DOCS/FOOTNOTE_FIXTURE.md
+++ b/DOCS/FOOTNOTE_FIXTURE.md
@@ -1,0 +1,12 @@
+# Footnote fixture
+
+This sentence has a footnote[^observed].
+
+The second definition below is never referenced. Some renderers still list it,
+some hide it, and some treat the syntax as ordinary text.
+
+[^observed]: This footnote is intentionally ordinary.
+[^orphan]: This definition is intentionally left without a reader.
+
+The fixture contains no links or executable content; it only compares
+footnote support across Markdown implementations.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/FOOTNOTE_FIXTURE.md` with one referenced footnote and one intentionally orphaned definition.

## Why it is harmless

The page is isolated documentation with no external links, configuration, or executable content. It simply compares how Markdown implementations display referenced and unreferenced footnotes.
