### PR TITLE
Add a Markdown task list fixture

### DIFF
--- a/DOCS/TASK_LIST_FIXTURE.md
+++ b/DOCS/TASK_LIST_FIXTURE.md
@@ -1,0 +1,14 @@
+# Task-list fixture
+
+GitHub turns the markers below into interactive checkboxes. The nesting and
+mixed states are intentional.
+
+- [x] Open the repository
+- [ ] Wonder whether this item is real
+  - [x] Inspect the raw Markdown
+  - [ ] Leave the box unchecked
+- [ ] Finish the experiment
+
+The boxes are documentation only; checking one does not trigger a workflow or
+record a task anywhere. Other Markdown renderers may display the markers as
+ordinary text.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/TASK_LIST_FIXTURE.md` with nested checked and unchecked task-list markers.

## Why it is harmless

The checkboxes are documentation-only and do not trigger workflows or persist state. The fixture is isolated under `DOCS/` and exists only to compare GitHub and other Markdown renderers.
