### PR TITLE
Add an entity and escape rendering fixture

### DIFF
--- a/DOCS/ENTITY_ESCAPE_FIXTURE.md
+++ b/DOCS/ENTITY_ESCAPE_FIXTURE.md
@@ -1,0 +1,12 @@
+# Entity and escape fixture
+
+The same characters appear in several contexts below:
+
+- `&copy;` stays literal inside code
+- &copy; becomes an HTML entity in normal text
+- `\*stars\*` keeps its asterisks
+- *stars* uses the asterisks as Markdown emphasis
+
+The distinctions are intentionally tiny. They let a renderer or sanitizer
+show which parsing layer handled each line. This page is plain text and does
+not embed executable HTML or scripts.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ENTITY_ESCAPE_FIXTURE.md` comparing HTML entities, code spans, escaped asterisks, and Markdown emphasis.

## Why it is harmless

The page is plain documentation with no executable HTML or scripts. It only makes parser/sanitizer differences visible and does not modify protected paths or runtime behavior.
