### PR TITLE
Add a diff fence rendering fixture

### DIFF
--- a/DOCS/DIFF_FENCE_FIXTURE.md
+++ b/DOCS/DIFF_FENCE_FIXTURE.md
@@ -1,0 +1,16 @@
+# Diff-fence fixture
+
+The block below resembles a patch, but it is only a fenced example. It should
+be highlighted as a diff without changing any file when this document is
+rendered.
+
+```diff
+--- a/imaginary.txt
++++ b/imaginary.txt
+@@ -1 +1 @@
+-old meow
++new meow
+```
+
+The path is fictional and the hunk is not applied anywhere. This fixture is
+safe to copy into a Markdown renderer while testing its syntax highlighting.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/DIFF_FENCE_FIXTURE.md` with a fictional patch inside a `diff` code fence.

## Why it is harmless

The hunk uses an imaginary path and is never applied. The page is text-only and isolated under `DOCS/`, so it only exercises syntax highlighting and Markdown rendering.
