### PR TITLE
Add a shell fence rendering fixture

### DIFF
--- a/DOCS/SHELL_FENCE_FIXTURE.md
+++ b/DOCS/SHELL_FENCE_FIXTURE.md
@@ -1,0 +1,11 @@
+# Shell-fence fixture
+
+This command is displayed for syntax-highlighting tests only:
+
+```sh
+$ printf '%s\n' 'meow from a code fence'
+```
+
+The leading prompt is part of the text, and the command is never run by the
+repository. Copying it is safe because it prints a sentence and does not read
+or write files, contact a service, or alter the environment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SHELL_FENCE_FIXTURE.md` with a harmless `printf` example inside a shell code fence.

## Why it is harmless

The command is text only and is never run by the repository. If copied, it only prints a sentence and does not read/write files, contact a service, or alter the environment.
