### PR TITLE
Add an HTML table rendering fixture

### DIFF
--- a/DOCS/HTML_TABLE_FIXTURE.md
+++ b/DOCS/HTML_TABLE_FIXTURE.md
@@ -1,0 +1,22 @@
+# HTML table fixture
+
+GitHub permits a small amount of HTML in Markdown. This table deliberately
+uses `rowspan` and `colspan` so that HTML-aware and Markdown-only renderers
+can be compared.
+
+<table>
+  <tr>
+    <th>path</th>
+    <th>signal</th>
+  </tr>
+  <tr>
+    <td rowspan="2">DOCS/</td>
+    <td>text</td>
+  </tr>
+  <tr>
+    <td colspan="2">one cell spans two columns</td>
+  </tr>
+</table>
+
+There are no scripts, forms, or remote resources in this fixture. Any odd
+layout is limited to this document's rendering.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/HTML_TABLE_FIXTURE.md` with a small HTML table using `rowspan` and `colspan`.

## Why it is harmless

The table has no scripts, forms, or remote resources. It is isolated documentation and only compares HTML-aware and Markdown-only rendering behavior.
