### PR TITLE
Add an open details rendering fixture

### DIFF
--- a/DOCS/DETAILS_FIXTURE.md
+++ b/DOCS/DETAILS_FIXTURE.md
@@ -1,0 +1,16 @@
+# Details fixture
+
+This disclosure block starts open so that its contents are visible immediately
+in browsers that support the `open` attribute.
+
+<details open>
+<summary>Open the harmless secret</summary>
+
+There is no secret here—only a sentence inside an HTML details block.
+
+*Markdown inside the block may or may not be interpreted by a renderer.*
+
+</details>
+
+The block has no script, event handler, or remote resource. It exists only to
+compare disclosure rendering across Markdown viewers.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/DETAILS_FIXTURE.md` with an `<details open>` block containing a short Markdown paragraph.

## Why it is harmless

The block has no scripts, event handlers, or remote resources. It is isolated documentation that only exercises disclosure and nested-Markdown rendering.
