### PR TITLE
Add duplicate heading anchor fixtures

### DIFF
--- a/DOCS/HEADING_COLLISIONS.md
+++ b/DOCS/HEADING_COLLISIONS.md
@@ -1,0 +1,17 @@
+# Heading collisions
+
+These headings intentionally produce very similar anchor candidates:
+
+## Same heading
+
+## Same heading
+
+## same heading
+
+<a id="same-heading"></a>
+
+## Same heading, one explicit id nearby
+
+Different Markdown engines may append suffixes, preserve case, or let the
+explicit HTML id win. The page is a navigation fixture only; it contains no
+scripts or external links.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/HEADING_COLLISIONS.md` with repeated headings, case differences, and an explicit nearby HTML id.

## Why it is harmless

The page is isolated Markdown/HTML text with no scripts or external links. It only exercises anchor generation and navigation behavior across renderers.
