### PR TITLE
Add Markdown link title fixtures

### DIFF
--- a/DOCS/LINK_TITLE_FIXTURE.md
+++ b/DOCS/LINK_TITLE_FIXTURE.md
@@ -1,0 +1,12 @@
+# Link-title fixture
+
+These links all target the same harmless local document but use different
+title punctuation:
+
+- [plain title](./NO_EXTENSION "a quiet title")
+- [apostrophe title](./NO_EXTENSION "cat's title")
+- [parentheses title](./NO_EXTENSION "title (with a note)")
+
+Hover text, quoting, and URL parsing may differ between Markdown viewers. The
+targets are local and already documented elsewhere; this page adds no network
+request or executable behavior.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/LINK_TITLE_FIXTURE.md` with local links using plain, apostrophe, and parenthesized titles.

## Why it is harmless

All targets stay inside the repository and already exist. The page is text-only and only exercises hover text, quoting, and URL parsing across Markdown viewers.
