### PR TITLE
Add an autolink rendering fixture

### DIFF
--- a/DOCS/AUTOLINK_FIXTURE.md
+++ b/DOCS/AUTOLINK_FIXTURE.md
@@ -1,0 +1,12 @@
+# Autolink fixture
+
+Angle brackets ask many Markdown renderers to turn the following text into
+links automatically:
+
+<https://break-this-repo.invalid/autolink>
+
+<maintainer@break-this-repo.invalid>
+
+Both destinations use reserved example names. The first should never resolve,
+and the second is an example address rather than a contact. This page tests
+autolinking without targeting a real website or mailbox.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/AUTOLINK_FIXTURE.md` with an example URL and email in angle brackets to exercise Markdown autolinking.

## Why it is harmless

Both use reserved `.invalid` names and are explicitly examples, not real destinations. The page is text-only and does not contact a website or mailbox.
