### PR TITLE
Add a path-with-space fixture

### DIFF
--- a/DOCS/SPACE NAME.md
+++ b/DOCS/SPACE NAME.md
@@ -1,0 +1,8 @@
+# Space in the path
+
+The space in this filename is intentional. Repository browsers should display
+it as part of the name, while shell commands and URL builders must quote or
+encode it correctly.
+
+This is a plain-text fixture with no configuration or executable content. The
+only thing under test is path handling.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SPACE NAME.md`, a text-only document whose path contains a space.

## Why it is harmless

The page has no configuration or executable content. It only exercises repository-browser display, shell quoting, and URL encoding for paths with spaces.
