### PR TITLE
Add a trailing-dot filename fixture

### DIFF
--- a/DOCS/TRAILING-DOT.
+++ b/DOCS/TRAILING-DOT.
@@ -1,0 +1,7 @@
+# Trailing-dot path
+
+The filename ends with a literal period. POSIX filesystems can preserve that
+character, while some Windows APIs trim trailing dots or reject the path.
+
+This page is plain text and exists solely to make that cross-platform behavior
+visible. It is not a configuration file and has no executable content.


### PR DESCRIPTION
## What this breaks

Adds a text-only document whose filename ends with a literal period: `DOCS/TRAILING-DOT.`.

## Why it is harmless

The file has no code or configuration. It only exposes how POSIX and Windows path APIs preserve, trim, or reject trailing dots, a cross-platform filename experiment explicitly encouraged by this repository.
