### PR TITLE
Add a leading-dash path fixture

### DIFF
--- a/DOCS/-leading-dash.md
+++ b/DOCS/-leading-dash.md
@@ -1,0 +1,11 @@
+# Leading-dash path
+
+This document intentionally starts with a hyphen in its filename. Command-line
+tools that accept paths as options may need `--` before the path, for example:
+
+```sh
+git add -- DOCS/-leading-dash.md
+```
+
+The example is not run by the repository and changes no configuration. The
+fixture only makes option/path disambiguation visible.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/-leading-dash.md`, a text-only path beginning with a hyphen, plus a fenced example showing the `--` separator.

## Why it is harmless

The command is not executed and no configuration or workflow is changed. The fixture only exercises option/path disambiguation in command-line tools.
