### PR TITLE
Add a hash-prefixed path fixture

### DIFF
--- a/DOCS/#hash.md
+++ b/DOCS/#hash.md
@@ -1,0 +1,8 @@
+# Hash-prefixed path
+
+The leading `#` is part of this filename. In an interactive shell an
+unquoted path beginning with `#` can look like a comment, while in a URL the
+same character usually introduces a fragment.
+
+This document is only a path-handling fixture. It contains no shell command,
+URL target, configuration, or executable content.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/#hash.md`, a text-only filename beginning with `#`, and documents its shell-comment and URL-fragment ambiguity.

## Why it is harmless

The page contains no shell command, URL target, configuration, or executable content. It only exercises quoting and path handling in repository tools.
