### PR TITLE
Add an at-sign path fixture

### DIFF
--- a/DOCS/@mention.md
+++ b/DOCS/@mention.md
@@ -1,0 +1,8 @@
+# At-sign path
+
+The `@` at the start of this filename is just a character in a path. In a
+GitHub discussion, an at-sign can start a user mention, but this filename is
+not a mention and should not notify anyone.
+
+The document contains only this explanation. It does not refer to a real
+account, configuration key, or external service.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/@mention.md`, a text-only filename beginning with `@`, and explains why it is not a GitHub mention.

## Why it is harmless

The file does not name an account, configuration key, or external service, so it cannot notify anyone or affect runtime behavior. It only exercises path and mention parsing.
