### PR TITLE
Add a bang-prefixed path fixture

### DIFF
--- a/DOCS/!bang.md
+++ b/DOCS/!bang.md
@@ -1,0 +1,8 @@
+# Bang-prefixed path
+
+The exclamation mark at the start of this filename is literal. Interactive
+shells may give `!` special history-expansion meaning, so scripts and humans
+should quote the path when they need to open it.
+
+This file is explanatory text only. It contains no shell command and cannot
+trigger history expansion by itself.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/!bang.md`, a text-only filename beginning with `!`, and documents shell history-expansion/path-quoting differences.

## Why it is harmless

The file contains no shell command and cannot trigger expansion by itself. It changes no configuration, workflow, runtime code, or external system.
