### PR TITLE
Add a nested Markdown fence fixture

### DIFF
--- a/DOCS/NESTED_FENCES.md
+++ b/DOCS/NESTED_FENCES.md
@@ -1,0 +1,14 @@
+# Nested fence fixture
+
+Four backticks fence this example so that the inner three-backtick fence stays
+visible as text:
+
+````markdown
+```text
+the inner fence is not the outer fence
+```
+````
+
+Renderers that count fence length correctly should show the inner fence inside
+the code block. The fixture contains no executable snippet; it only tests
+delimiter parsing.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/NESTED_FENCES.md`, using a four-backtick outer fence around a three-backtick inner fence.

## Why it is harmless

The content is documentation-only and contains no executable snippet. It exercises delimiter counting and code-block parsing across Markdown renderers.
