### PR TITLE
Add a setext heading ambiguity fixture

### DIFF
--- a/DOCS/SETEXT_AMBIGUITY.md
+++ b/DOCS/SETEXT_AMBIGUITY.md
@@ -1,0 +1,12 @@
+# Setext ambiguity
+
+In Markdown, a line of dashes can underline a heading or stand alone as a
+horizontal rule depending on what comes before it.
+
+This is a title
+---
+
+---
+
+The first pair should be a setext heading; the second should be a rule. The
+fixture is plain text and exists only to compare parser decisions.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SETEXT_AMBIGUITY.md` comparing a dash underline that forms a setext heading with a standalone horizontal rule.

## Why it is harmless

The fixture is plain Markdown under `DOCS/` with no code, configuration, or external links. It only compares parser decisions.
