### PR TITLE
Add a definition list compatibility fixture

### DIFF
--- a/DOCS/DEFINITION_LIST.md
+++ b/DOCS/DEFINITION_LIST.md
@@ -1,0 +1,13 @@
+# Definition-list fixture
+
+The syntax below is recognized by some Markdown dialects but not by strict
+CommonMark:
+
+Repository
+: a place where files gather
+
+Chaos
+: a feature, according to the surrounding documentation
+
+Renderers may turn this into a definition list or leave the colon-prefixed
+lines as ordinary paragraphs. It is a text-only compatibility experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/DEFINITION_LIST.md` using definition-list syntax supported by some Markdown dialects but not strict CommonMark.

## Why it is harmless

The page is text-only and isolated under `DOCS/`. It changes no runtime or workflow behavior and only compares renderer fallbacks.
