### PR TITLE
Add strike and underline Markdown fixtures

### DIFF
--- a/DOCS/STRIKE_UNDERLINE.md
+++ b/DOCS/STRIKE_UNDERLINE.md
@@ -1,0 +1,11 @@
+# Strike and underline fixture
+
+These lines mix Markdown's deletion marker with underscore emphasis:
+
+- ~~this is struck through~~
+- __this is strong emphasis__
+- _this is emphasis_
+- \_literal underscores\_
+
+The combinations are intentionally small so that renderers can be compared
+without involving HTML or scripts. This page has no runtime effect.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/STRIKE_UNDERLINE.md` comparing strikethrough, underscore emphasis, and escaped underscores.

## Why it is harmless

The page is plain Markdown under `DOCS/` with no HTML, scripts, external links, or runtime effect. It only exercises parser behavior.
