### PR TITLE
Add an ordered-list numbering fixture

### DIFF
--- a/DOCS/ORDERED_LIST_FIXTURE.md
+++ b/DOCS/ORDERED_LIST_FIXTURE.md
@@ -1,0 +1,12 @@
+# Ordered-list fixture
+
+The explicit numbers below start at unusual values on purpose:
+
+0. Count from zero
+1. Continue normally
+42. Jump to the answer
+   1. Nested item one
+   3. Nested item three
+
+Markdown renderers may preserve, normalize, or ignore the written numbers.
+This page is text-only and does not encode a real checklist or process.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ORDERED_LIST_FIXTURE.md` with zero-based, jumped, and nested ordered-list numbers.

## Why it is harmless

The page is text-only and does not encode a real process or checklist. It only exercises how Markdown renderers preserve or normalize written list numbers.
