### PR TITLE
Add a Markdown line break fixture

### DIFF
--- a/DOCS/LINE_BREAK_FIXTURE.md
+++ b/DOCS/LINE_BREAK_FIXTURE.md
@@ -1,0 +1,16 @@
+# Line-break fixture
+
+The following paragraphs use three different ways to suggest a line break:
+
+ordinary line one
+ordinary line two
+
+hard break with a backslash\
+the next line
+
+hard break with HTML<br>
+the next line
+
+Renderers may collapse the first pair while honoring one or both hard-break
+forms. The page has no scripts or external references; it is only a Markdown
+line-break experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/LINE_BREAK_FIXTURE.md` comparing ordinary newlines, a backslash hard break, and an HTML `<br>` break.

## Why it is harmless

The page contains only Markdown/HTML text with no scripts or external references. It exists solely to compare line-break rendering behavior.
