### PR TITLE
Add an angle-bracket link destination fixture

### DIFF
--- a/DOCS/ANGLE_DESTINATION.md
+++ b/DOCS/ANGLE_DESTINATION.md
@@ -1,0 +1,10 @@
+# Angle-bracket destination
+
+Markdown permits a link destination with spaces when it is wrapped in angle
+brackets:
+
+[Open the path with a space](<./SPACE NAME.md>)
+
+The target is the existing local fixture added for the path-with-space
+experiment. Renderers that omit the angle-bracket rule may misparse the link;
+the page itself has no external or executable content.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ANGLE_DESTINATION.md` with a local link whose space-containing destination is wrapped in angle brackets.

## Why it is harmless

The target already exists inside the repository. The page has no external or executable content and only exercises Markdown destination parsing.
