### PR TITLE
Add Markdown reference label fixtures

### DIFF
--- a/DOCS/REFERENCE_LABELS.md
+++ b/DOCS/REFERENCE_LABELS.md
@@ -1,0 +1,14 @@
+# Reference-label fixture
+
+These labels differ only by case:
+
+[upper label][A label]
+
+[lower label][a label]
+
+[A label]: ./NO_EXTENSION
+[a label]: ./SPACE%20NAME.md
+
+Some Markdown implementations compare labels case-insensitively, while others
+keep them distinct. Both destinations are local text fixtures; this page does
+not create a network request or execute anything.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/REFERENCE_LABELS.md` with two reference labels that differ only by case and point to local text fixtures.

## Why it is harmless

The destinations stay inside the repository and the page contains no executable content. It only compares case-sensitive and case-insensitive reference-label parsing.
