### PR TITLE
Add an escaped table pipe fixture

### DIFF
--- a/DOCS/ESCAPED_TABLE.md
+++ b/DOCS/ESCAPED_TABLE.md
@@ -1,0 +1,12 @@
+# Escaped-table fixture
+
+The first row contains a literal pipe inside a cell; the second puts the pipe
+inside a code span. Both should remain one cell in a Markdown-aware renderer.
+
+| expression | meaning |
+| --- | --- |
+| `cat \| dog` | escaped separator |
+| `cat | dog` | code span with a pipe |
+
+If a parser splits either value into extra columns, the mismatch is visible in
+the preview. This is an isolated text fixture with no executable content.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ESCAPED_TABLE.md` comparing an escaped pipe and a literal pipe inside a Markdown table/code span.

## Why it is harmless

The page is an isolated text fixture with no executable content. It only exposes how Markdown parsers split or preserve pipe characters in table cells.
