### PR TITLE
Add an empty video fallback fixture

### DIFF
--- a/DOCS/VIDEO_FIXTURE.md
+++ b/DOCS/VIDEO_FIXTURE.md
@@ -1,0 +1,11 @@
+# Video fallback fixture
+
+This element has controls but no source. Browsers that support HTML video may
+show an empty player; other viewers should display the fallback sentence.
+
+<video controls>
+  This browser does not render the empty video fixture.
+</video>
+
+There is intentionally no `src`, script, or remote resource. The experiment is
+limited to how a renderer handles a media element with nothing to load.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/VIDEO_FIXTURE.md` with an HTML `<video controls>` element that intentionally has no source.

## Why it is harmless

There is no `src`, script, or remote resource. The page only compares empty-media and fallback rendering behavior and cannot load or execute anything.
