### PR TITLE
Add an empty audio fallback fixture

### DIFF
--- a/DOCS/AUDIO_FIXTURE.md
+++ b/DOCS/AUDIO_FIXTURE.md
@@ -1,0 +1,11 @@
+# Audio fallback fixture
+
+This element has controls but no source, so a browser has nothing to fetch or
+play:
+
+<audio controls>
+  This browser does not render the empty audio fixture.
+</audio>
+
+There is no `src`, script, or remote resource. The page only compares empty
+media and fallback-text rendering.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/AUDIO_FIXTURE.md` with an HTML `<audio controls>` element that has no source.

## Why it is harmless

No `src`, script, or remote resource is present, so nothing is fetched or played. The page only compares empty-media and fallback-text rendering.
