### PR TITLE
Add an invalid time element fixture

### DIFF
--- a/DOCS/TIME_FIXTURE.md
+++ b/DOCS/TIME_FIXTURE.md
@@ -1,0 +1,10 @@
+# Time-element fixture
+
+The `datetime` attribute below uses a date that does not exist in the
+Gregorian calendar (2099 is not a leap year):
+
+<time datetime="2099-02-29">the impossible day after February 28</time>
+
+Browsers and accessibility tools may preserve the visible text while rejecting
+or ignoring the machine-readable value. This is a text-only rendering fixture;
+there is no script, scheduling action, or external service.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/TIME_FIXTURE.md` with a `<time>` element whose machine-readable date is intentionally impossible (2099-02-29).

## Why it is harmless

The page contains no scheduling action, script, or external service. It only compares how browsers and accessibility tools preserve visible text while handling an invalid datetime value.
