### PR TITLE
Add an indented code block fixture

### DIFF
--- a/DOCS/INDENTED_CODE.md
+++ b/DOCS/INDENTED_CODE.md
@@ -1,0 +1,10 @@
+# Indented-code fixture
+
+The four-space block below should be parsed as code, while the final sentence
+is ordinary prose.
+
+    meow = "plain text inside an indented block"
+    print(meow)
+
+No tool executes these lines. The fixture only compares legacy indented-code
+parsing with fenced-code parsing.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/INDENTED_CODE.md` with a four-space indented code block followed by ordinary prose.

## Why it is harmless

The lines are never executed; the page is an isolated Markdown fixture comparing indented and fenced code parsing.
