### PR TITLE
Add an index of repository fixtures

### DIFF
--- a/DOCS/FIXTURE_INDEX.md
+++ b/DOCS/FIXTURE_INDEX.md
@@ -1,0 +1,15 @@
+# Fixture index
+
+The repository now contains many tiny experiments. This index points to a few
+representative ones so that a new contributor can find the breakage without
+searching the entire tree.
+
+| area | examples |
+| --- | --- |
+| Links | [broken URL](./BROKEN_LINK_LEDGER.md), [broken image](./BROKEN_IMAGE.md), [autolink](./AUTOLINK_FIXTURE.md) |
+| Paths | [case-sensitive pair](./case-sensitivity-lab/UPPER.txt), [Unicode path](./🧪.md), [space in a name](<./SPACE NAME.md>) |
+| Markdown | [nested fences](./NESTED_FENCES.md), [ragged table](./RAGGED_TABLE.md), [footnotes](./FOOTNOTE_FIXTURE.md) |
+| HTML | [details block](./DETAILS_FIXTURE.md), [HTML table](./HTML_TABLE_FIXTURE.md), [empty video](./VIDEO_FIXTURE.md) |
+
+Each linked page explains its own intentional failure mode and stays confined
+to repository-local text or markup.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/FIXTURE_INDEX.md`, a small categorized index linking to representative experiments already merged into the repository.

## Why it is harmless

All links target existing repository-local text/markup. The index changes no runtime code, workflows, protected content, or external systems; it simply makes the accumulated experiments discoverable.
