### PR TITLE
Add a percent-encoded URL fixture

### DIFF
--- a/DOCS/ESCAPED_URL.md
+++ b/DOCS/ESCAPED_URL.md
@@ -1,0 +1,11 @@
+# Escaped URL fixture
+
+The two links below try to reach the same path, but only one percent-encodes
+the space:
+
+- [encoded](./SPACE%20NAME.md)
+- [literal](./SPACE NAME.md)
+
+The first form is URL-safe; the second tests whether a renderer encodes it on
+the reader's behalf. Both destinations are local and contain only explanatory
+text, so this page has no external side effects.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ESCAPED_URL.md` linking to the existing space-containing document with encoded and literal spaces.

## Why it is harmless

Both targets are repository-local text. The page has no external links or executable content and only compares URL encoding behavior in Markdown renderers.
