### PR TITLE
Add a query and fragment link fixture

### DIFF
--- a/DOCS/QUERY_FRAGMENT.md
+++ b/DOCS/QUERY_FRAGMENT.md
@@ -1,0 +1,10 @@
+# Query-and-fragment fixture
+
+This link points at an existing local file but adds a query string and a
+fragment that the file does not define:
+
+[Open the file with imaginary parameters](./NO_EXTENSION?mode=cat&noise=1#missing-section)
+
+Browsers may ignore the query, scroll nowhere for the fragment, or hand both
+to a static host. The destination remains inside the repository; this page has
+no real network or executable behavior.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/QUERY_FRAGMENT.md` with a local link carrying an imaginary query string and an undefined fragment.

## Why it is harmless

The target is an existing repository-local text file; no external service is contacted. The fixture only compares static-host handling of query and fragment components.
