### PR TITLE
Add an invalid data value fixture

### DIFF
--- a/DOCS/DATA_VALUE_FIXTURE.md
+++ b/DOCS/DATA_VALUE_FIXTURE.md
@@ -1,0 +1,10 @@
+# Data-value fixture
+
+The `data` element pairs visible text with a machine-readable value. This
+example intentionally uses a non-numeric value for something that looks like a
+count:
+
+<data value="many">many cats</data>
+
+Assistive tools may expose the value, the label, or both. There is no script or
+data consumer in this repository; the element is only a rendering fixture.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/DATA_VALUE_FIXTURE.md` with a `<data>` element whose visible count has the non-numeric machine-readable value `many`.

## Why it is harmless

The element is isolated documentation with no script or data consumer. It only compares how browsers and assistive tools expose visible labels versus `value` attributes.
