### PR TITLE
Add an abbreviation rendering fixture

### DIFF
--- a/DOCS/ABBR_FIXTURE.md
+++ b/DOCS/ABBR_FIXTURE.md
@@ -1,0 +1,10 @@
+# Abbreviation fixture
+
+The same short label appears with and without an HTML expansion:
+
+- <abbr title="Break This Repository">BTR</abbr>
+- BTR
+
+Hover text and assistive technology may expose the title differently. The
+page contains no script or external resource; it is only an annotation
+rendering experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ABBR_FIXTURE.md` comparing an `<abbr title>` label with the same plain text.

## Why it is harmless

The page is isolated documentation with no script or external resource. It only exercises hover and assistive-technology annotation rendering.
