### PR TITLE
Add semantic citation fixtures

### DIFF
--- a/DOCS/SEMANTIC_CITE.md
+++ b/DOCS/SEMANTIC_CITE.md
@@ -1,0 +1,11 @@
+# Semantic citation fixture
+
+These lines carry semantic HTML tags but no quotation or source lookup:
+
+<cite>The Cat's Unfinished Manual</cite>
+
+<q>break it gently</q>
+
+Plain text says the same thing without markup. Browsers and assistive tools may
+style or announce the tagged forms differently. The page has no external
+source, script, or executable behavior.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SEMANTIC_CITE.md` comparing `<cite>`, `<q>`, and plain text.

## Why it is harmless

The tags carry no external source, script, or executable behavior. The page is isolated documentation and only exercises semantic/accessible rendering.
