### PR TITLE
Add a ruby annotation fixture

### DIFF
--- a/DOCS/RUBY_FIXTURE.md
+++ b/DOCS/RUBY_FIXTURE.md
@@ -1,0 +1,9 @@
+# Ruby annotation fixture
+
+The `ruby` element pairs a character with a pronunciation hint:
+
+<ruby>猫<rt>ねこ</rt></ruby>
+
+Browsers with ruby support may place the reading above the base text; other
+viewers should keep both strings readable inline. The page has no script or
+external resource and exists only to compare annotation rendering.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/RUBY_FIXTURE.md` with a `<ruby>/<rt>` annotation for a Japanese character.

## Why it is harmless

The page contains only semantic text and no scripts or external resources. It compares ruby-capable and fallback rendering for East Asian annotations.
