### PR TITLE
Add a keyboard markup fixture

### DIFF
--- a/DOCS/KBD_FIXTURE.md
+++ b/DOCS/KBD_FIXTURE.md
@@ -1,0 +1,9 @@
+# Keyboard-markup fixture
+
+The `<kbd>` element gives key names semantic markup:
+
+<kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Meow</kbd>
+
+Browsers may render the labels like keycaps, while plain-text viewers keep the
+angle brackets visible. This page does not bind the combination or listen for
+input; it is only a static rendering experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/KBD_FIXTURE.md` with semantic `<kbd>` labels for a fictional key combination.

## Why it is harmless

The page is static text: it does not bind the combination, listen for input, run code, or contact an external resource. It only compares keycap rendering and plain-text fallback.
