### PR TITLE
Add a sample output markup fixture

### DIFF
--- a/DOCS/SAMP_FIXTURE.md
+++ b/DOCS/SAMP_FIXTURE.md
@@ -1,0 +1,9 @@
+# Sample-output fixture
+
+The `<samp>` element marks output produced by a program:
+
+<samp>meow: no such command</samp>
+
+It is only an annotation here. No command is run, no error is generated, and
+no shell or external service is involved. Renderers may style the sample
+differently from ordinary prose.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SAMP_FIXTURE.md` with a semantic `<samp>` example-output label.

## Why it is harmless

The sentence is annotation only: no command runs, no error is generated, and no shell or external service is involved. It only compares semantic styling to ordinary prose.
