### PR TITLE
Add a variable markup fixture

### DIFF
--- a/DOCS/VAR_FIXTURE.md
+++ b/DOCS/VAR_FIXTURE.md
@@ -1,0 +1,9 @@
+# Variable-markup fixture
+
+The `<var>` element identifies a variable in a formula:
+
+<var>meow</var> = <var>cats</var> + <var>curiosity</var>
+
+The expression is fictional and has no evaluator behind it. A renderer may
+style the variables differently or expose the semantic role to assistive
+technology; this document does nothing beyond displaying the text.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/VAR_FIXTURE.md` with a fictional formula using semantic `<var>` tags.

## Why it is harmless

No evaluator, script, or external resource exists behind the expression. The page only compares semantic styling and accessibility behavior with ordinary text.
