### PR TITLE
Add mark and small semantic fixtures

### DIFF
--- a/DOCS/MARK_SMALL_FIXTURE.md
+++ b/DOCS/MARK_SMALL_FIXTURE.md
@@ -1,0 +1,10 @@
+# Mark-and-small fixture
+
+The tags below add emphasis and supporting text without changing the words:
+
+<mark>important-looking meow</mark>
+
+<small>footnote-sized meow</small>
+
+Plain text viewers should still expose both phrases. The page has no style
+sheet or script; it only compares semantic annotation and visual fallback.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/MARK_SMALL_FIXTURE.md` comparing `<mark>` and `<small>` semantic annotations with plain text.

## Why it is harmless

The page has no stylesheet or script and is isolated under `DOCS/`. It only exercises semantic annotation and visual fallback behavior.
