### PR TITLE
Add insert and delete semantic fixtures

### DIFF
--- a/DOCS/INS_DEL_FIXTURE.md
+++ b/DOCS/INS_DEL_FIXTURE.md
@@ -1,0 +1,9 @@
+# Insert-and-delete fixture
+
+The tags below describe a fictional documentation edit:
+
+<del>the old cat rule</del> <ins>the new cat rule</ins>
+
+Browsers may strike or underline the phrases, while plain-text viewers keep
+both visible. This is a static semantic example; it does not modify any other
+file or trigger a change elsewhere.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/INS_DEL_FIXTURE.md` with `<del>` and `<ins>` annotations for a fictional edit.

## Why it is harmless

The tags are static text and do not modify any other file or trigger a change. The page only compares semantic insertion/deletion rendering and plain-text fallback.
