### PR TITLE
Add a definition term fixture

### DIFF
--- a/DOCS/DFN_FIXTURE.md
+++ b/DOCS/DFN_FIXTURE.md
@@ -1,0 +1,9 @@
+# Definition-term fixture
+
+The `<dfn>` element marks the term being defined:
+
+<dfn>repository chaos</dfn> means a collection of harmless experiments.
+
+Some user agents style the term or expose its role to assistive technology;
+others render it as ordinary text. This document has no glossary engine or
+executable behavior behind the annotation.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/DFN_FIXTURE.md` with a semantic `<dfn>` term and a fictional definition.

## Why it is harmless

The annotation has no glossary engine or executable behavior behind it. The page only compares semantic styling/accessibility to ordinary text.
