### PR TITLE
Add an incomplete HTML definition list fixture

### DIFF
--- a/DOCS/HTML_DL_FIXTURE.md
+++ b/DOCS/HTML_DL_FIXTURE.md
@@ -1,0 +1,13 @@
+# HTML definition-list fixture
+
+The second term below intentionally has no `<dd>` description:
+
+<dl>
+  <dt>cat</dt>
+  <dd>a small observer</dd>
+  <dt>mystery</dt>
+</dl>
+
+HTML-aware browsers may keep the orphan term, move it, or ignore it. Markdown
+viewers may display the tags literally. The incomplete structure is confined to
+this document and has no script or external resource.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/HTML_DL_FIXTURE.md` with an intentionally orphaned `<dt>` in a definition list.

## Why it is harmless

The incomplete structure is isolated documentation with no scripts or external resources. It only compares HTML-aware and Markdown-only fallback rendering.
