### PR TITLE
Add a caption-only figure fixture

### DIFF
--- a/DOCS/FIGURE_FIXTURE.md
+++ b/DOCS/FIGURE_FIXTURE.md
@@ -1,0 +1,12 @@
+# Figure fixture
+
+This figure intentionally contains a caption but no image or other figure
+content:
+
+<figure>
+  <figcaption>A caption looking for its missing picture</figcaption>
+</figure>
+
+HTML-aware viewers may reserve figure spacing or style the caption; plain text
+viewers should show the words inline. No asset, script, or remote resource is
+referenced by this page.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/FIGURE_FIXTURE.md` with a `<figure>` containing a caption but no image or other body content.

## Why it is harmless

No asset, script, or remote resource is referenced. The page only compares semantic figure spacing and caption fallback across viewers.
