### PR TITLE
Add an incomplete picture fallback fixture

### DIFF
--- a/DOCS/PICTURE_FIXTURE.md
+++ b/DOCS/PICTURE_FIXTURE.md
@@ -1,0 +1,13 @@
+# Picture fallback fixture
+
+This `<picture>` has a source candidate but intentionally omits its fallback
+`img` element:
+
+<picture>
+  <source media="(min-width: 1px)" srcset="./missing-picture.png">
+  No fallback image was supplied.
+</picture>
+
+Browsers may show nothing, expose the fallback sentence, or report a missing
+source. The path is local and nonexistent; no remote asset, script, or data is
+involved.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/PICTURE_FIXTURE.md` with a source candidate but no fallback `<img>` element.

## Why it is harmless

The source points at a nonexistent local asset and there is no script or remote resource. The page only compares browser fallback behavior for incomplete picture markup.
