### PR TITLE
Add an object fallback fixture

### DIFF
--- a/DOCS/OBJECT_FIXTURE.md
+++ b/DOCS/OBJECT_FIXTURE.md
@@ -1,0 +1,11 @@
+# Object fallback fixture
+
+The object below points at a missing local resource and includes fallback text:
+
+<object data="./missing-object.bin" type="application/octet-stream">
+  No object was found.
+</object>
+
+Browsers may hide the fallback, show it, or report a failed object load. The
+target does not exist and no remote resource, script, or executable payload is
+involved.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/OBJECT_FIXTURE.md` with an `<object>` element targeting a nonexistent local resource and providing fallback text.

## Why it is harmless

The target does not exist and no remote resource, script, or executable payload is present. The page only compares failed-object and fallback rendering.
