### PR TITLE
Add a canvas fallback fixture

### DIFF
--- a/DOCS/CANVAS_FIXTURE.md
+++ b/DOCS/CANVAS_FIXTURE.md
@@ -1,0 +1,11 @@
+# Canvas fallback fixture
+
+This canvas has dimensions but no drawing script:
+
+<canvas width="240" height="60">
+  A browser without canvas support should show this sentence.
+</canvas>
+
+Modern browsers may reserve a blank rectangle, while other viewers expose the
+fallback text. The page intentionally includes no script, event handler, or
+external resource.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/CANVAS_FIXTURE.md` with a dimensioned `<canvas>` element but no drawing script.

## Why it is harmless

The page contains no script, event handler, or external resource. It only compares blank-canvas and fallback-text rendering across browsers and text viewers.
