### PR TITLE
Add disabled input rendering fixtures

### DIFF
--- a/DOCS/INPUT_FIXTURE.md
+++ b/DOCS/INPUT_FIXTURE.md
@@ -1,0 +1,10 @@
+# Disabled input fixture
+
+These controls are deliberately disabled and are not wrapped in a form:
+
+<label>Consent to more chaos <input type="checkbox" disabled></label>
+
+<label>Read-only name <input value="cat" readonly></label>
+
+The controls cannot submit data or trigger an action. This page only compares
+browser form-control rendering and label association with plain-text viewers.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/INPUT_FIXTURE.md` with disabled and readonly HTML inputs.

## Why it is harmless

The controls are not inside a form, cannot submit data, and have no action or script attached. The page only compares browser control rendering and label association.
