### PR TITLE
Add a conflicting select control fixture

### DIFF
--- a/DOCS/SELECT_FIXTURE.md
+++ b/DOCS/SELECT_FIXTURE.md
@@ -1,0 +1,12 @@
+# Select-control fixture
+
+This disabled control intentionally marks two options as selected:
+
+<select disabled>
+  <option selected>first cat</option>
+  <option selected>second cat</option>
+</select>
+
+HTML parsers may keep the first selection, the last selection, or normalize the
+markup. Because the control is disabled and not inside a form, it cannot submit
+anything; the page only compares fallback behavior.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SELECT_FIXTURE.md` with a disabled `<select>` whose two options are both marked `selected`.

## Why it is harmless

The control is disabled and outside any form, so it cannot submit data. The page only compares HTML parser normalization and fallback rendering.
