### PR TITLE
Add a readonly textarea fixture

### DIFF
--- a/DOCS/TEXTAREA_FIXTURE.md
+++ b/DOCS/TEXTAREA_FIXTURE.md
@@ -1,0 +1,12 @@
+# Textarea fixture
+
+This readonly textarea combines a placeholder with initial line breaks:
+
+<textarea rows="3" cols="28" placeholder="write nothing" readonly>
+first line
+second line
+</textarea>
+
+Browsers may preserve the whitespace, trim it, or display the placeholder
+instead. The control is not in a form and cannot submit anything; this page is
+only a static rendering experiment.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/TEXTAREA_FIXTURE.md` with a readonly multiline `<textarea>` carrying a placeholder and initial line breaks.

## Why it is harmless

The control is outside any form and cannot submit data. It only exercises whitespace, placeholder, and fallback rendering in a static document.
