### PR TITLE
Add a disabled button fixture

### DIFF
--- a/DOCS/BUTTON_FIXTURE.md
+++ b/DOCS/BUTTON_FIXTURE.md
@@ -1,0 +1,9 @@
+# Disabled-button fixture
+
+This button is intentionally disabled and has no form or click handler:
+
+<button type="button" disabled>Meow later</button>
+
+Browsers may gray it out, announce its disabled state, or render it as plain
+text in a Markdown viewer. Nothing can be submitted or triggered from this
+document; the element is only a static control fixture.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/BUTTON_FIXTURE.md` with a disabled button that has no form or click handler.

## Why it is harmless

Nothing can be submitted or triggered from this document. It only compares disabled-control styling and accessibility announcements across viewers.
