### PR TITLE
Add an output element fixture

### DIFF
--- a/DOCS/OUTPUT_FIXTURE.md
+++ b/DOCS/OUTPUT_FIXTURE.md
@@ -1,0 +1,9 @@
+# Output-element fixture
+
+This output is not associated with a form or a calculation:
+
+<output>the answer is probably meow</output>
+
+Some browsers and assistive tools may announce the element as generated output;
+others may style it as ordinary text. No computation, form submission, or
+script exists behind this static example.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/OUTPUT_FIXTURE.md` with an unassociated `<output>` element.

## Why it is harmless

No computation, form submission, or script exists behind the example. It only compares semantic output announcements and ordinary-text fallback.
