### PR TITLE
Refresh the fixture index

### DIFF
--- a/DOCS/FIXTURE_INDEX.md
+++ b/DOCS/FIXTURE_INDEX.md
@@ -10,6 +10,8 @@ searching the entire tree.
 | Paths | [case-sensitive pair](./case-sensitivity-lab/UPPER.txt), [Unicode path](./🧪.md), [space in a name](<./SPACE NAME.md>) |
 | Markdown | [nested fences](./NESTED_FENCES.md), [ragged table](./RAGGED_TABLE.md), [footnotes](./FOOTNOTE_FIXTURE.md) |
 | HTML | [details block](./DETAILS_FIXTURE.md), [HTML table](./HTML_TABLE_FIXTURE.md), [empty video](./VIDEO_FIXTURE.md) |
+| Semantic HTML | [keyboard](./KBD_FIXTURE.md), [sample output](./SAMP_FIXTURE.md), [variable](./VAR_FIXTURE.md), [ruby](./RUBY_FIXTURE.md) |
+| Controls | [disabled input](./INPUT_FIXTURE.md), [select](./SELECT_FIXTURE.md), [textarea](./TEXTAREA_FIXTURE.md), [button](./BUTTON_FIXTURE.md) |
 
 Each linked page explains its own intentional failure mode and stays confined
 to repository-local text or markup.


### PR DESCRIPTION
## What this breaks

Extends `DOCS/FIXTURE_INDEX.md` with links to the recently merged semantic HTML and disabled-control fixtures.

## Why it is harmless

Every new link targets an existing repository-local document. This is a documentation-maintenance change with no runtime, workflow, protected-path, or external-system impact.
