### PR TITLE
Add an access-key fixture

### DIFF
--- a/DOCS/ACCESSKEY_FIXTURE.md
+++ b/DOCS/ACCESSKEY_FIXTURE.md
@@ -1,0 +1,9 @@
+# Access-key fixture
+
+This anchor exposes an access key but intentionally has no destination:
+
+<a accesskey="m">Press the platform's access-key combination for meow</a>
+
+Browser shortcuts and assistive tools may announce or activate the label in
+different ways. With no `href`, the element cannot navigate anywhere; this is a
+static keyboard-accessibility experiment only.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ACCESSKEY_FIXTURE.md` with an `accesskey` label that has no navigation target.

## Why it is harmless

The anchor has no `href`, script, or external target, so it cannot navigate or contact a service. It only exercises keyboard-accessibility rendering.

The commit includes playful Claude co-author trailers using reserved example addresses; they are not claims of real external authorship.
