### PR TITLE
Add an address element fixture

### DIFF
--- a/DOCS/ADDRESS_FIXTURE.md
+++ b/DOCS/ADDRESS_FIXTURE.md
@@ -1,0 +1,14 @@
+# Address-element fixture
+
+This address block names an imaginary office rather than a real person or
+contact point:
+
+<address>
+  The Department of Harmless Cat Experiments<br>
+  404 Meow Lane<br>
+  Nowhere, .invalid
+</address>
+
+The `.invalid` label is reserved for examples. No mail link, phone number,
+location, or external service is attached; the page only tests semantic address
+rendering and line breaks.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ADDRESS_FIXTURE.md` with a semantic `<address>` block for an imaginary office using the reserved `.invalid` label.

## Why it is harmless

There is no real contact, mail link, phone number, location, or external service. The page only tests semantic address rendering and line breaks.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are explicitly not claims of real external authorship.
