### PR TITLE
Add an open dialog fixture

### DIFF
--- a/DOCS/DIALOG_FIXTURE.md
+++ b/DOCS/DIALOG_FIXTURE.md
@@ -1,0 +1,12 @@
+# Dialog fixture
+
+This dialog is open in the markup but has no form, buttons, or script to act
+on it:
+
+<dialog open>
+  This is a static message, not a prompt for real input.
+</dialog>
+
+Browsers may draw a dialog surface or ignore the element; text viewers should
+show the sentence inline. No data can be submitted and no external resource is
+loaded by this page.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/DIALOG_FIXTURE.md` with an open `<dialog>` element that has no form, buttons, or script.

## Why it is harmless

The page cannot submit data or load an external resource. It only compares dialog and inline-text rendering.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
