### PR TITLE
Add a word-break opportunity fixture

### DIFF
--- a/DOCS/WBR_FIXTURE.md
+++ b/DOCS/WBR_FIXTURE.md
@@ -1,0 +1,9 @@
+# Word-break opportunity fixture
+
+The long token below includes an explicit `<wbr>` opportunity:
+
+supercalifragilistic<wbr>expialidocious
+
+Narrow layouts may break at that point; wide layouts may keep the word on one
+line. The element adds no script, link, or external resource—it only exposes
+word-wrapping differences.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/WBR_FIXTURE.md` with a long word and an explicit `<wbr>` break opportunity.

## Why it is harmless

The page contains no scripts, links, or external resources. It only exposes narrow-versus-wide word-wrapping behavior.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
