### PR TITLE
Add semantic landmark fixtures

### DIFF
--- a/DOCS/LANDMARK_FIXTURE.md
+++ b/DOCS/LANDMARK_FIXTURE.md
@@ -1,0 +1,14 @@
+# Landmark fixture
+
+These landmarks intentionally contain only short text:
+
+<nav aria-label="Imaginary navigation">
+  <a href="#meow">Meow</a>
+</nav>
+
+<main id="meow">
+  The destination is an empty local anchor.
+</main>
+
+Screen readers may announce the navigation and main landmarks; plain-text
+viewers should show the tags inline. The page has no script or external target.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/LANDMARK_FIXTURE.md` with `nav` and `main` landmarks and an empty local anchor.

## Why it is harmless

The target stays inside the document, and no script or external resource is involved. It only compares landmark announcements and plain-text fallback.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
