### PR TITLE
Add section and article fixtures

### DIFF
--- a/DOCS/SECTION_ARTICLE_FIXTURE.md
+++ b/DOCS/SECTION_ARTICLE_FIXTURE.md
@@ -1,0 +1,13 @@
+# Section and article fixture
+
+These semantic containers are intentionally short and nested:
+
+<section aria-label="A section that says meow">
+  <article>
+    One self-contained article about a fictional cat.
+  </article>
+</section>
+
+Screen readers may announce the section label and article boundary; plain-text
+viewers simply show the words. There is no script, navigation, or external
+resource behind this markup.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/SECTION_ARTICLE_FIXTURE.md` with a labeled `<section>` containing a short `<article>`.

## Why it is harmless

The markup has no script, navigation, or external resource and only compares semantic boundary announcements to plain-text rendering.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
