### PR TITLE
Add header and footer fixtures

### DIFF
--- a/DOCS/HEADER_FOOTER_FIXTURE.md
+++ b/DOCS/HEADER_FOOTER_FIXTURE.md
@@ -1,0 +1,12 @@
+# Header and footer fixture
+
+This miniature article has semantic boundaries but no site navigation:
+
+<article>
+  <header>Header with no menu</header>
+  <p>A single paragraph in the middle.</p>
+  <footer>Footer with no legal notice</footer>
+</article>
+
+Assistive tools may announce the regions, while Markdown viewers may flatten
+them. The page contains no links, scripts, or external resources.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/HEADER_FOOTER_FIXTURE.md` with semantic `<header>` and `<footer>` boundaries around a short article.

## Why it is harmless

There are no links, scripts, or external resources. The page only compares landmark announcements and flattened Markdown rendering.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
