### PR TITLE
Add an aside landmark fixture

### DIFF
--- a/DOCS/ASIDE_FIXTURE.md
+++ b/DOCS/ASIDE_FIXTURE.md
@@ -1,0 +1,11 @@
+# Aside fixture
+
+The note below is an `aside` without a surrounding article:
+
+<aside aria-label="An optional cat note">
+  This paragraph is supplementary, not a warning.
+</aside>
+
+Screen readers may expose the label as a complementary landmark; Markdown-only
+viewers may flatten it into prose. No script, link, or external resource is
+attached.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/ASIDE_FIXTURE.md` with an `aside` complementary landmark and an accessible label.

## Why it is harmless

The note has no script, link, or external resource. It only compares screen-reader landmark announcements with Markdown-only flattening.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
