### PR TITLE
Add an unusual HTML ordered list fixture

### DIFF
--- a/DOCS/HTML_OL_FIXTURE.md
+++ b/DOCS/HTML_OL_FIXTURE.md
@@ -1,0 +1,12 @@
+# HTML ordered-list fixture
+
+This list starts at zero and uses a reversed item, both intentionally unusual:
+
+<ol start="0" reversed>
+  <li>zero-ish cat</li>
+  <li>previous cat</li>
+</ol>
+
+Browsers may honor the attributes, normalize them, or ignore them in a
+Markdown-only viewer. The list is not a process or checklist and has no script
+behind it.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/HTML_OL_FIXTURE.md` with an HTML ordered list using `start="0"` and `reversed`.

## Why it is harmless

The list is not a process or checklist and has no script behind it. It only compares browser attribute handling with Markdown-only fallback.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
