### PR TITLE
Index semantic landmark fixtures

### DIFF
--- a/DOCS/FIXTURE_INDEX.md
+++ b/DOCS/FIXTURE_INDEX.md
@@ -12,6 +12,8 @@ searching the entire tree.
 | HTML | [details block](./DETAILS_FIXTURE.md), [HTML table](./HTML_TABLE_FIXTURE.md), [empty video](./VIDEO_FIXTURE.md) |
 | Semantic HTML | [keyboard](./KBD_FIXTURE.md), [sample output](./SAMP_FIXTURE.md), [variable](./VAR_FIXTURE.md), [ruby](./RUBY_FIXTURE.md) |
 | Controls | [disabled input](./INPUT_FIXTURE.md), [select](./SELECT_FIXTURE.md), [textarea](./TEXTAREA_FIXTURE.md), [button](./BUTTON_FIXTURE.md) |
+| Landmarks | [nav/main](./LANDMARK_FIXTURE.md), [section/article](./SECTION_ARTICLE_FIXTURE.md), [header/footer](./HEADER_FOOTER_FIXTURE.md), [aside](./ASIDE_FIXTURE.md) |
+| Empty media | [picture](./PICTURE_FIXTURE.md), [object](./OBJECT_FIXTURE.md), [canvas](./CANVAS_FIXTURE.md), [dialog](./DIALOG_FIXTURE.md) |
 
 Each linked page explains its own intentional failure mode and stays confined
 to repository-local text or markup.


### PR DESCRIPTION
## What this breaks

Extends `DOCS/FIXTURE_INDEX.md` with links to the recently merged landmark, semantic-container, and empty-media fixtures.

## Why it is harmless

Every link targets an existing repository-local document; this is documentation maintenance only.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
