### PR TITLE
Add a disabled fieldset fixture

### DIFF
--- a/DOCS/FIELDSET_FIXTURE.md
+++ b/DOCS/FIELDSET_FIXTURE.md
@@ -1,0 +1,12 @@
+# Fieldset fixture
+
+This disabled group has a legend and a control, but no form around it:
+
+<fieldset disabled>
+  <legend>Optional cat preferences</legend>
+  <label><input type="checkbox"> extra whiskers</label>
+</fieldset>
+
+Browsers may gray the whole group and assistive tools may announce the legend.
+Nothing can be submitted from this document; the markup only tests grouping and
+disabled-state rendering.


### PR DESCRIPTION
## What this breaks

Adds `DOCS/FIELDSET_FIXTURE.md` with a disabled `<fieldset>`, legend, and checkbox outside any form.

## Why it is harmless

Nothing can be submitted and no script or external resource is present. The page only tests grouping, legend announcements, and disabled-state rendering.

The commit includes playful Claude Code / Claude Fable 5 MAX co-author trailers using reserved example addresses; they are not claims of real external authorship.
