### PR TITLE
Remove Rust language attribute from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* linguist-language=Rust
+


### PR DESCRIPTION
# 💥 Repository Destruction Report

## What did you break?

<!-- Explain the intended effect. -->

## Type of Destruction

- [ ] README chaos
- [ ] Broken documentation
- [ ] Harmless code failure
- [ ] GitHub rendering experiment
- [ ] Cross-platform Git experiment
- [ ] Cat-related incident
- [ ] Other unexplained phenomenon

## Verification

- [ ] I did ~~not~~ modify `.github/`.
- [ ] I did ~~not~~ modify the protected README section.
- [ ] The damage stays inside this repository.
- [ ] ~~No~~ credentials, malware, or personal information were added.
- [ ] I explained how to observe the effect.

## Final Statement

> I solemnly confirm that this repository is now slightly more broken.

> Nothing from above is actually required...or they do?
